### PR TITLE
Convert to ShoppingRD with API-based products

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="surja_ecommerce"
+        android:label="ShoppingRD"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/lib/components/cart_item.dart
+++ b/lib/components/cart_item.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:surja_ecommerce/models/cart.dart';
+import 'package:shopping_rd/models/cart.dart';
 
-import '../models/shoe.dart';
+import '../models/product.dart';
 
 class CartItem extends StatefulWidget {
-  Shoe shoe;
-   CartItem({super.key, required this.shoe});
+  Product product;
+  CartItem({super.key, required this.product});
 
   @override
   State<CartItem> createState() => _CartItemState();
@@ -16,7 +16,7 @@ class _CartItemState extends State<CartItem> {
 
   //remove item from cart
 void removeItemFromCart(){
-  Provider.of<Cart>(context, listen:false).removeItemFromCart(widget.shoe);
+  Provider.of<Cart>(context, listen:false).removeItemFromCart(widget.product);
 }
 
   @override
@@ -27,11 +27,11 @@ void removeItemFromCart(){
       ),
       margin: const EdgeInsets.only(bottom:10),
       child: ListTile(
-        leading: widget.shoe.imagePath.startsWith('http')
-            ? Image.network(widget.shoe.imagePath)
-            : Image.asset(widget.shoe.imagePath),
-        title: Text(widget.shoe.name),
-        subtitle: Text(widget.shoe.price),
+        leading: widget.product.imagePath.startsWith('http')
+            ? Image.network(widget.product.imagePath)
+            : Image.asset(widget.product.imagePath),
+        title: Text(widget.product.name),
+        subtitle: Text(widget.product.price),
         trailing: IconButton(icon:Icon(Icons.delete), 
         onPressed: removeItemFromCart,
         ),

--- a/lib/components/product_tile.dart
+++ b/lib/components/product_tile.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:surja_ecommerce/models/shoe.dart';
+import 'package:shopping_rd/models/product.dart';
 
-class ShoeTile extends StatelessWidget {
-  Shoe shoe;
+class ProductTile extends StatelessWidget {
+  Product product;
   void Function()? onTap;
-   ShoeTile({super.key, required this.shoe, required this.onTap});
+  ProductTile({super.key, required this.product, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -17,19 +17,19 @@ class ShoeTile extends StatelessWidget {
       Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-        //shoe
+        //product image
         ClipRRect(
           borderRadius: BorderRadius.circular(12),
-          child: shoe.imagePath.startsWith('http')
-              ? Image.network(shoe.imagePath)
-              : Image.asset(shoe.imagePath),
+          child: product.imagePath.startsWith('http')
+              ? Image.network(product.imagePath)
+              : Image.asset(product.imagePath),
         ),
           
 
         //description
         Padding(
           padding: const EdgeInsets.symmetric(horizontal:20.0),
-          child: Text(shoe.description, style:TextStyle(color: Colors.grey[600])),
+          child: Text(product.description, style:TextStyle(color: Colors.grey[600])),
         ),
 
         //price details
@@ -43,10 +43,10 @@ class ShoeTile extends StatelessWidget {
                 children: 
               
               [
-                Text(shoe.name, style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20,),
+                Text(product.name, style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20,),
                 ),
                 const SizedBox(height: 3),
-                Text('Rs.'+shoe.price, style: TextStyle(color:Colors.grey,),),
+                Text('Rs.'+product.price, style: TextStyle(color:Colors.grey,),),
                 
           
           

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:surja_ecommerce/models/cart.dart';
-import 'package:surja_ecommerce/pages/intro_page.dart';
+import 'package:shopping_rd/models/cart.dart';
+import 'package:shopping_rd/pages/intro_page.dart';
 
 void main() {
   runApp(const MyApp());

--- a/lib/models/cart.dart
+++ b/lib/models/cart.dart
@@ -1,44 +1,54 @@
 import 'package:flutter/material.dart';
 
-import 'shoe.dart';
+import 'product.dart';
+import '../services/fake_store_api.dart';
+import '../services/woocommerce_service.dart';
 
 class Cart extends ChangeNotifier{
-  //list of shoes for sale
-  List<Shoe> shoeShop =[
-    Shoe(name: 'Max HM02', price: ' 4000', description: 'Shoe in Blue', imagePath: 'lib/images/blue.jpg'),
-    Shoe(name: 'Air Jordan ', price: ' 1200', description: 'Shoe in Red', imagePath: 'lib/images/red.jpg'),
-    Shoe(name: 'CP Runner', price: ' 2400', description: 'Shoe in Neon', imagePath: 'lib/images/green.jpg'),
-    Shoe(name: 'Rockstar 92', price: ' 4600', description: 'Shoe in Gold', imagePath: 'lib/images/yellow.jpg'),
-  ];
+  //list of products for sale
+  List<Product> productShop = [];
 
   //list of items in user cart
 
-  List<Shoe> userCart=[];
+  List<Product> userCart=[];
 
-  //getting list of shoes for sale
-  List<Shoe> getShoeList()
+  //load products from APIs
+  Future<void> loadProducts() async {
+    final fakeProducts = await FakeStoreApi.fetchProducts();
+    final wooService = WooCommerceService(
+      baseUrl: 'https://example.com',
+      consumerKey: 'ck_your_key',
+      consumerSecret: 'cs_your_secret',
+    );
+    final wooProducts = await wooService.fetchProducts();
+    productShop = [...fakeProducts, ...wooProducts];
+    notifyListeners();
+  }
+
+  //getting list of products for sale
+  List<Product> getProductList()
   {
-    return shoeShop;
+    return productShop;
 
   }
 
   //get cart
-  List<Shoe> getUserCart()
+  List<Product> getUserCart()
   {
     return userCart;
   }
 
   //add items to cart
-  void addItemToCart(Shoe shoe)
+  void addItemToCart(Product product)
   {
-    userCart.add(shoe);
+    userCart.add(product);
     notifyListeners();
   }
 
   //remove items from cart
-void removeItemFromCart(Shoe shoe)
+void removeItemFromCart(Product product)
 {
-  userCart.remove(shoe);
+  userCart.remove(product);
   notifyListeners();
 }
 }

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -1,11 +1,11 @@
-class Shoe{
+class Product {
   final String name;
   final String price;
   final String imagePath;
   final String description;
 
   //constructor
-  Shoe({
+  Product({
     required this.name, required this.price, required this.description, required this.imagePath,
   });
 }

--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../components/cart_item.dart';
 import '../models/cart.dart';
-import '../models/shoe.dart';
+import '../models/product.dart';
 
 class CartPage extends StatelessWidget {
   const CartPage({super.key});
@@ -25,11 +25,11 @@ class CartPage extends StatelessWidget {
            Expanded(child: ListView.builder(
             itemCount:value.getUserCart().length,
             itemBuilder:(context, index){
-            //get individual shoe
-            Shoe individualShoe = value.getUserCart()[index];
+            //get individual product
+            Product individualProduct = value.getUserCart()[index];
 
             //return the cart item.
-            return CartItem(shoe:individualShoe,);
+            return CartItem(product:individualProduct,);
 
            },
            ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:surja_ecommerce/components/bottom_nav_bar.dart';
+import 'package:shopping_rd/components/bottom_nav_bar.dart';
 
 import 'cart_page.dart';
 import 'shop_page.dart';

--- a/lib/pages/intro_page.dart
+++ b/lib/pages/intro_page.dart
@@ -26,7 +26,7 @@ class IntroPage extends StatelessWidget {
           
           
               //title
-              const Text('eShop-Dex', style: TextStyle(
+              const Text('ShoppingRD', style: TextStyle(
               fontWeight: FontWeight.bold,
               fontSize:20,
               ),
@@ -34,7 +34,7 @@ class IntroPage extends StatelessWidget {
               const  SizedBox(height:18),
           
               //sub title
-              const Text('Brand new sneakers and custom running shoes made with premium quality', style: TextStyle(
+              const Text('Encuentra todo lo que necesitas en un solo lugar', style: TextStyle(
               
               fontSize:15,
               color:Colors.grey,

--- a/lib/pages/shop_page.dart
+++ b/lib/pages/shop_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../components/shoe_tile.dart';
+import '../components/product_tile.dart';
 import '../models/cart.dart';
-import '../models/shoe.dart';
+import '../models/product.dart';
 
 class ShopPage extends StatefulWidget {
   const ShopPage({super.key});
@@ -13,10 +13,12 @@ class ShopPage extends StatefulWidget {
 }
 
 class _ShopPageState extends State<ShopPage> {
-  //adding shoe to cart method
-  void addShoeToCart(Shoe shoe)
+  bool _isLoading = true;
+
+  //adding product to cart method
+  void addProductToCart(Product product)
   {
-Provider.of<Cart>(context, listen:false).addItemToCart(shoe);
+Provider.of<Cart>(context, listen:false).addItemToCart(product);
 
 //alert added successfully
 showDialog(context: context, builder:(context) => AlertDialog(
@@ -25,9 +27,21 @@ showDialog(context: context, builder:(context) => AlertDialog(
 ),
 );
   }
+
+  @override
+  void initState() {
+    super.initState();
+    Provider.of<Cart>(context, listen: false).loadProducts().then((_) {
+      setState(() {
+        _isLoading = false;
+      });
+    });
+  }
   @override
   Widget build(BuildContext context) {
-    return Consumer<Cart>(builder: (context, value, child)=>Column(
+    return Consumer<Cart>(builder: (context, value, child) => _isLoading
+        ? const Center(child: CircularProgressIndicator())
+        : Column(
       children: [
         //search bar
         Container( 
@@ -63,15 +77,15 @@ showDialog(context: context, builder:(context) => AlertDialog(
         const SizedBox(height:10),
 
         Expanded(child: ListView.builder(
-          itemCount: 4,
+          itemCount: value.getProductList().length,
           scrollDirection: Axis.horizontal,
           itemBuilder: (context, index) {
-          //create a shoe
-          Shoe shoe= value.getShoeList()[index];
+          //create a product
+          Product product = value.getProductList()[index];
 
-          //return shoe
-          return ShoeTile(shoe: shoe,
-          onTap: () => addShoeToCart(shoe),
+          //return product
+          return ProductTile(product: product,
+          onTap: () => addProductToCart(product),
           );
 
         },

--- a/lib/services/fake_store_api.dart
+++ b/lib/services/fake_store_api.dart
@@ -1,19 +1,19 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import '../models/shoe.dart';
+import '../models/product.dart';
 
 /// Service class for interacting with the Fake Store API.
 class FakeStoreApi {
   static const String _baseUrl = 'https://fakestoreapi.com';
 
   /// Fetches a list of products from the Fake Store API and converts them to
-  /// [Shoe] objects used by the app.
-  static Future<List<Shoe>> fetchProducts() async {
+  /// [Product] objects used by the app.
+  static Future<List<Product>> fetchProducts() async {
     final response = await http.get(Uri.parse('$_baseUrl/products'));
     if (response.statusCode == 200) {
       final List<dynamic> data = jsonDecode(response.body);
       return data
-          .map((item) => Shoe(
+          .map((item) => Product(
                 name: item['title'] ?? 'Unknown',
                 price: item['price'].toString(),
                 description: item['description'] ?? '',

--- a/lib/services/woocommerce_service.dart
+++ b/lib/services/woocommerce_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import '../models/shoe.dart';
+import '../models/product.dart';
 
 /// A minimal WooCommerce REST API client for fetching products.
 class WooCommerceService {
@@ -14,9 +14,9 @@ class WooCommerceService {
     required this.consumerSecret,
   });
 
-  /// Fetches products from the WooCommerce store and converts them to [Shoe]
+  /// Fetches products from the WooCommerce store and converts them to [Product]
   /// objects used by the app.
-  Future<List<Shoe>> fetchProducts() async {
+  Future<List<Product>> fetchProducts() async {
     final uri = Uri.parse(
       '$baseUrl/wp-json/wc/v3/products?consumer_key=$consumerKey&consumer_secret=$consumerSecret',
     );
@@ -24,7 +24,7 @@ class WooCommerceService {
     if (response.statusCode == 200) {
       final List<dynamic> data = jsonDecode(response.body);
       return data
-          .map((item) => Shoe(
+          .map((item) => Product(
                 name: item['name'] ?? 'Unknown',
                 price: item['price'] ?? '0',
                 description: item['description'] ?? '',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: surja_ecommerce
+name: shopping_rd
 description: "A new Flutter project."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:surja_ecommerce/main.dart';
+import 'package:shopping_rd/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="surja_ecommerce">
+  <meta name="apple-mobile-web-app-title" content="ShoppingRD">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>surja_ecommerce</title>
+  <title>ShoppingRD</title>
   <link rel="manifest" href="manifest.json">
 
   <script>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "surja_ecommerce",
-    "short_name": "surja_ecommerce",
+    "name": "ShoppingRD",
+    "short_name": "ShoppingRD",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
## Summary
- rename project to **ShoppingRD**
- generalize model to `Product` and update UI
- load items from FakeStore and WooCommerce APIs
- update intro text and app labels
- adjust imports and web metadata

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886c9bdf2fc8321a9d124fdc699de12