### PR TITLE
Handle WooCommerce API errors

### DIFF
--- a/lib/models/cart.dart
+++ b/lib/models/cart.dart
@@ -14,14 +14,27 @@ class Cart extends ChangeNotifier{
 
   //load products from APIs
   Future<void> loadProducts() async {
-    final fakeProducts = await FakeStoreApi.fetchProducts();
+    final List<Product> allProducts = [];
+
+    try {
+      allProducts.addAll(await FakeStoreApi.fetchProducts());
+    } catch (_) {
+      // Ignore network errors from the fake store API
+    }
+
     final wooService = WooCommerceService(
       baseUrl: 'https://example.com',
       consumerKey: 'ck_your_key',
       consumerSecret: 'cs_your_secret',
     );
-    final wooProducts = await wooService.fetchProducts();
-    productShop = [...fakeProducts, ...wooProducts];
+
+    try {
+      allProducts.addAll(await wooService.fetchProducts());
+    } catch (_) {
+      // Errors are already handled inside [fetchProducts]
+    }
+
+    productShop = allProducts;
     notifyListeners();
   }
 

--- a/lib/services/woocommerce_service.dart
+++ b/lib/services/woocommerce_service.dart
@@ -20,21 +20,27 @@ class WooCommerceService {
     final uri = Uri.parse(
       '$baseUrl/wp-json/wc/v3/products?consumer_key=$consumerKey&consumer_secret=$consumerSecret',
     );
-    final response = await http.get(uri);
-    if (response.statusCode == 200) {
-      final List<dynamic> data = jsonDecode(response.body);
-      return data
-          .map((item) => Product(
-                name: item['name'] ?? 'Unknown',
-                price: item['price'] ?? '0',
-                description: item['description'] ?? '',
-                imagePath: item['images'] != null && item['images'].isNotEmpty
-                    ? item['images'][0]['src']
-                    : '',
-              ))
-          .toList();
-    } else {
-      throw Exception('Failed to load WooCommerce products');
+    try {
+      final response = await http.get(uri);
+      if (response.statusCode == 200) {
+        final List<dynamic> data = jsonDecode(response.body);
+        return data
+            .map((item) => Product(
+                  name: item['name'] ?? 'Unknown',
+                  price: item['price'] ?? '0',
+                  description: item['description'] ?? '',
+                  imagePath: item['images'] != null && item['images'].isNotEmpty
+                      ? item['images'][0]['src']
+                      : '',
+                ))
+            .toList();
+      } else {
+        // Unexpected status code - return an empty list
+        return [];
+      }
+    } catch (e) {
+      // Any network or decoding errors are ignored
+      return [];
     }
   }
 }


### PR DESCRIPTION
## Summary
- handle failures in WooCommerceService
- handle errors when loading products from the APIs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886cc91400c8321b61d0821c1098213