### PR TITLE
Fix redirect for GoRouter 13

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,7 @@ class MyApp extends StatelessWidget {
             redirect: (context, state) {
               final loggedIn = auth.isLoggedIn;
               final isAdmin = auth.isAdmin;
-              final loc = state.subloc;
+              final loc = state.matchedLocation;
               if (!loggedIn && loc != '/login') return '/login';
               if (loggedIn && loc == '/login') return '/home';
               if (loc == '/admin' && !isAdmin) return '/home';


### PR DESCRIPTION
## Summary
- use GoRouterState.matchedLocation property for redirect

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d09432248321931dc72ab07dd7ee