### PR TITLE
Add category filter and Spanish strings

### DIFF
--- a/lib/components/product_tile.dart
+++ b/lib/components/product_tile.dart
@@ -37,7 +37,8 @@ class ProductTile extends StatelessWidget {
               textAlign: TextAlign.center,
             ),
           ),
-          Text('Rs. ${product.price}', style: TextStyle(color: Colors.grey[600])),
+          Text('RD\$ ${product.price}',
+              style: TextStyle(color: Colors.grey[600])),
           const SizedBox(height: 8),
           ElevatedButton(
             onPressed: onTap,

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -3,9 +3,14 @@ class Product {
   final String price;
   final String imagePath;
   final String description;
+  final String category;
 
-  //constructor
+  /// Basic product model used throughout the app.
   Product({
-    required this.name, required this.price, required this.description, required this.imagePath,
+    required this.name,
+    required this.price,
+    required this.description,
+    required this.imagePath,
+    this.category = 'General',
   });
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -16,14 +16,18 @@ class _HomePageState extends State<HomePage> {
   bool _loading = true;
   final TextEditingController _searchController = TextEditingController();
   String _searchQuery = '';
-  final List<String> _categories = ['Todos', 'Ofertas', 'Electrónica', 'Ropa'];
+  final List<String> _categories = ['Todos'];
   String _selectedCategory = 'Todos';
 
   @override
   void initState() {
     super.initState();
     Provider.of<Cart>(context, listen: false).loadProducts().then((_) {
+      final products =
+          Provider.of<Cart>(context, listen: false).getProductList();
+      final uniqueCats = products.map((p) => p.category).toSet();
       setState(() {
+        _categories.addAll(uniqueCats);
         _loading = false;
       });
     });
@@ -49,9 +53,13 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     final cart = context.watch<Cart>();
     final allProducts = cart.getProductList();
-    final products = allProducts
-        .where((p) => p.name.toLowerCase().contains(_searchQuery.toLowerCase()))
-        .toList();
+    final products = allProducts.where((p) {
+      final matchesSearch =
+          p.name.toLowerCase().contains(_searchQuery.toLowerCase());
+      final matchesCategory =
+          _selectedCategory == 'Todos' || p.category == _selectedCategory;
+      return matchesSearch && matchesCategory;
+    }).toList();
     final cartCount = cart.getUserCart().length;
 
     return Scaffold(
@@ -175,7 +183,7 @@ class _HomePageState extends State<HomePage> {
                             Padding(
                               padding: const EdgeInsets.symmetric(horizontal: 8.0),
                               child: Text(
-                                'Rs. ${product.price}',
+                                'RD\$ ${product.price}',
                                 style: TextStyle(color: Colors.grey[600]),
                               ),
                             ),

--- a/lib/pages/intro_page.dart
+++ b/lib/pages/intro_page.dart
@@ -56,7 +56,7 @@ class IntroPage extends StatelessWidget {
                   padding: EdgeInsets.all(25),
                   child:const Center(
                   child: const Text(
-                    'Shop Now', 
+                    'Compra ahora',
                     style: TextStyle(color: Colors.white,
                     fontWeight:FontWeight.bold,
                     fontSize: 15,

--- a/lib/services/fake_store_api.dart
+++ b/lib/services/fake_store_api.dart
@@ -18,6 +18,7 @@ class FakeStoreApi {
                 price: item['price'].toString(),
                 description: item['description'] ?? '',
                 imagePath: item['image'] ?? '',
+                category: item['category'] ?? 'General',
               ))
           .toList();
     } else {

--- a/lib/services/woocommerce_service.dart
+++ b/lib/services/woocommerce_service.dart
@@ -32,6 +32,9 @@ class WooCommerceService {
                   imagePath: item['images'] != null && item['images'].isNotEmpty
                       ? item['images'][0]['src']
                       : '',
+                  category: item['categories'] != null && item['categories'].isNotEmpty
+                      ? item['categories'][0]['name']
+                      : 'General',
                 ))
             .toList();
       } else {


### PR DESCRIPTION
## Summary
- localize intro button text
- support categories in Product model and fetch from APIs
- allow category-based filtering on home page
- show prices with `RD$` instead of `Rs.`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6886df261f508321aa837414ba416332