### PR TITLE
Fix returning from cart page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'pages/intro_page.dart';
 import 'pages/home_page.dart';
 import 'pages/login_page.dart';
 import 'pages/admin_page.dart';
+import 'pages/cart_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -40,6 +41,10 @@ class MyApp extends StatelessWidget {
               GoRoute(
                 path: '/home',
                 builder: (context, state) => const HomePage(),
+              ),
+              GoRoute(
+                path: '/cart',
+                builder: (context, state) => const CartPage(),
               ),
               GoRoute(
                 path: '/admin',

--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -15,7 +15,7 @@ class CartPage extends StatelessWidget {
         title: const Text('Mi Carrito'),
         leading: IconButton(
           icon: const Icon(Icons.home),
-          onPressed: () => context.go('/home'),
+          onPressed: () => context.pop(),
         ),
       ),
       body: Consumer<Cart>(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/cart.dart';
 import '../models/product.dart';
-import 'cart_page.dart';
 import 'login_page.dart';
+import 'package:go_router/go_router.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -38,9 +38,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   void _openCart() {
-    Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => const CartPage()),
-    );
+    context.push('/cart');
   }
 
   @override


### PR DESCRIPTION
## Summary
- add missing route for the cart page
- navigate to Cart via `context.push`
- pop the cart page using GoRouter when pressing the Home icon

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e33866148321a74838e9408e17f9