### PR TITLE
Disallow repeated login

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ class MyApp extends StatelessWidget {
             redirect: (context, state) {
               final isAdmin = auth.isAdmin;
               final loc = state.matchedLocation;
+              if (loc == '/login' && auth.isLoggedIn) return '/home';
               if (loc == '/admin' && !isAdmin) return '/home';
               return null;
             },

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../models/cart.dart';
 import '../models/product.dart';
 import 'login_page.dart';
+import '../providers/auth_provider.dart';
 import 'package:go_router/go_router.dart';
 
 class HomePage extends StatefulWidget {
@@ -59,18 +60,20 @@ class _HomePageState extends State<HomePage> {
       return matchesSearch && matchesCategory;
     }).toList();
     final cartCount = cart.getUserCart().length;
+    final auth = context.watch<AuthProvider>();
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('ShoppingRD'),
         centerTitle: false,
         actions: [
-          IconButton(
-            icon: const Icon(Icons.login),
-            onPressed: () => Navigator.of(context).push(
-              MaterialPageRoute(builder: (_) => const LoginPage()),
+          if (!auth.isLoggedIn)
+            IconButton(
+              icon: const Icon(Icons.login),
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const LoginPage()),
+              ),
             ),
-          ),
           Stack(
             children: [
               IconButton(

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -18,6 +18,10 @@ class _LoginPageState extends State<LoginPage> {
 
   void _submit() {
     final auth = Provider.of<AuthProvider>(context, listen: false);
+    if (auth.isLoggedIn) {
+      setState(() => _error = 'Ya has iniciado sesión');
+      return;
+    }
     final success = auth.login(_emailController.text, _passwordController.text);
     if (success) {
       context.go('/home');

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -14,6 +14,7 @@ class AuthProvider extends ChangeNotifier {
   bool get isAdmin => _currentUser?.isAdmin ?? false;
 
   bool login(String email, String password) {
+    if (isLoggedIn) return false;
     try {
       final user = _users.firstWhere(
         (u) => u.email == email && u.password == password,


### PR DESCRIPTION
## Summary
- prevent login when a session already exists
- show an error on the login page when already logged in
- hide the login button on the home page when logged in
- redirect `/login` to `/home` if the user is logged in

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e4f5b51483218265e7dd78b348df