### PR TITLE
Add admin draft controls to home

### DIFF
--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -1,9 +1,10 @@
 class Product {
-  final String name;
-  final String price;
-  final String imagePath;
-  final String description;
-  final String category;
+  String name;
+  String price;
+  String imagePath;
+  String description;
+  String category;
+  bool isDraft;
 
   /// Basic product model used throughout the app.
   Product({
@@ -12,5 +13,6 @@ class Product {
     required this.description,
     required this.imagePath,
     this.category = 'General',
+    this.isDraft = false,
   });
 }

--- a/lib/pages/admin_page.dart
+++ b/lib/pages/admin_page.dart
@@ -16,6 +16,7 @@ class _AdminPageState extends State<AdminPage> {
   final TextEditingController _price = TextEditingController();
   final TextEditingController _description = TextEditingController();
   final TextEditingController _image = TextEditingController();
+  bool _draft = false;
 
   void _addProduct() {
     final cart = Provider.of<Cart>(context, listen: false);
@@ -24,6 +25,7 @@ class _AdminPageState extends State<AdminPage> {
       price: _price.text,
       description: _description.text,
       imagePath: _image.text,
+      isDraft: _draft,
     );
     cart.productShop.add(product);
     cart.notifyListeners();
@@ -31,6 +33,7 @@ class _AdminPageState extends State<AdminPage> {
     _price.clear();
     _description.clear();
     _image.clear();
+    _draft = false;
   }
 
   @override
@@ -59,6 +62,11 @@ class _AdminPageState extends State<AdminPage> {
                 controller: _image,
                 decoration: const InputDecoration(labelText: 'Image URL'),
               ),
+              SwitchListTile(
+                title: const Text('Draft'),
+                value: _draft,
+                onChanged: (value) => setState(() => _draft = value),
+              ),
               const SizedBox(height: 10),
               ElevatedButton(
                 onPressed: _addProduct,
@@ -74,12 +82,26 @@ class _AdminPageState extends State<AdminPage> {
                   return ListTile(
                     title: Text(product.name),
                     subtitle: Text(product.price),
-                    trailing: IconButton(
-                      icon: const Icon(Icons.delete),
-                      onPressed: () {
-                        cart.productShop.removeAt(index);
-                        cart.notifyListeners();
-                      },
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Switch(
+                          value: product.isDraft,
+                          onChanged: (val) {
+                            setState(() {
+                              product.isDraft = val;
+                            });
+                            cart.notifyListeners();
+                          },
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () {
+                            cart.productShop.removeAt(index);
+                            cart.notifyListeners();
+                          },
+                        ),
+                      ],
                     ),
                   );
                 },

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -57,7 +57,8 @@ class _HomePageState extends State<HomePage> {
           p.name.toLowerCase().contains(_searchQuery.toLowerCase());
       final matchesCategory =
           _selectedCategory == 'Todos' || p.category == _selectedCategory;
-      return matchesSearch && matchesCategory;
+      final isPublished = !p.isDraft;
+      return matchesSearch && matchesCategory && isPublished;
     }).toList();
     final cartCount = cart.getUserCart().length;
     final auth = context.watch<AuthProvider>();
@@ -83,6 +84,11 @@ class _HomePageState extends State<HomePage> {
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(builder: (_) => const LoginPage()),
               ),
+            ),
+          if (auth.isAdmin)
+            IconButton(
+              icon: const Icon(Icons.admin_panel_settings),
+              onPressed: () => context.push('/admin'),
             ),
           Stack(
             children: [

--- a/lib/services/fake_store_api.dart
+++ b/lib/services/fake_store_api.dart
@@ -19,6 +19,7 @@ class FakeStoreApi {
                 description: item['description'] ?? '',
                 imagePath: item['image'] ?? '',
                 category: item['category'] ?? 'General',
+                isDraft: false,
               ))
           .toList();
     } else {

--- a/lib/services/woocommerce_service.dart
+++ b/lib/services/woocommerce_service.dart
@@ -35,6 +35,7 @@ class WooCommerceService {
                   category: item['categories'] != null && item['categories'].isNotEmpty
                       ? item['categories'][0]['name']
                       : 'General',
+                  isDraft: false,
                 ))
             .toList();
       } else {


### PR DESCRIPTION
## Summary
- allow products to be flagged as drafts
- expose admin panel from the home page
- let admins toggle draft status for each product

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e8225bac8321a17a0b610cf1d908