### PR TITLE
Add cart payment option

### DIFF
--- a/lib/models/cart.dart
+++ b/lib/models/cart.dart
@@ -80,6 +80,12 @@ class Cart extends ChangeNotifier{
     notifyListeners();
   }
 
+  // remove all items from cart
+  void clearCart() {
+    userCart.clear();
+    notifyListeners();
+  }
+
   //remove items from cart
 void removeItemFromCart(Product product)
 {

--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../components/cart_item.dart';
 import '../models/cart.dart';
+import '../services/payment_service.dart';
 
 class CartPage extends StatelessWidget {
   const CartPage({super.key});
@@ -51,6 +52,31 @@ class CartPage extends StatelessWidget {
                       .toList(),
                 ],
               ],
+            ),
+          );
+        },
+      ),
+      bottomNavigationBar: Consumer<Cart>(
+        builder: (context, cart, child) {
+          final items = cart.getUserCart();
+          if (items.isEmpty) return const SizedBox.shrink();
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: ElevatedButton(
+              onPressed: () async {
+                final success = await PaymentService.processPayment(items);
+                if (success) {
+                  cart.clearCart();
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Pago completado')),
+                  );
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Error al procesar pago')),
+                  );
+                }
+              },
+              child: const Text('Pagar'),
             ),
           );
         },

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/product.dart';
+
+/// Basic payment service used to simulate a checkout call.
+class PaymentService {
+  static const String _endpoint = 'https://jsonplaceholder.typicode.com/posts';
+
+  /// Sends a POST request with cart items to a dummy API.
+  /// Returns `true` if the request was successful.
+  static Future<bool> processPayment(List<Product> items) async {
+    try {
+      final response = await http.post(
+        Uri.parse(_endpoint),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({
+          'items': items
+              .map((p) => {
+                    'name': p.name,
+                    'price': p.price,
+                  })
+              .toList(),
+        }),
+      );
+      return response.statusCode == 201;
+    } catch (_) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `PaymentService` with a simple POST call
- expose `clearCart` in `Cart` model
- add checkout button to the cart page that uses `PaymentService`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886ea0d38d48321839f77bc5c0a23d8