### PR TITLE
Fetch 194 DummyJSON products

### DIFF
--- a/lib/components/product_tile.dart
+++ b/lib/components/product_tile.dart
@@ -10,7 +10,7 @@ class ProductTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.only(left: 12),
-      width: 120,
+      width: 100,
       decoration: BoxDecoration(
         color: Colors.grey[100],
         borderRadius: BorderRadius.circular(8),
@@ -19,7 +19,7 @@ class ProductTile extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           SizedBox(
-            height: 80,
+            height: 70,
             child: ClipRRect(
               borderRadius: BorderRadius.circular(8),
               child: product.imagePath.startsWith('http')
@@ -42,7 +42,7 @@ class ProductTile extends StatelessWidget {
           const SizedBox(height: 8),
           ElevatedButton(
             onPressed: onTap,
-            style: ElevatedButton.styleFrom(minimumSize: const Size(110, 30)),
+            style: ElevatedButton.styleFrom(minimumSize: const Size(100, 30)),
             child: const Text('Agregar al carrito'),
           ),
           const SizedBox(height: 8),

--- a/lib/cubits/cart_cubit.dart
+++ b/lib/cubits/cart_cubit.dart
@@ -39,7 +39,10 @@ class CartCubit extends Cubit<CartState> {
     }
 
     try {
-      allProducts.addAll(await DummyJsonService.fetchProducts());
+      // Fetch all available DummyJSON products in a single call.
+      allProducts.addAll(
+        await DummyJsonService.fetchProducts(limit: 194),
+      );
     } catch (_) {
       // Ignore network errors from the DummyJSON API
     }

--- a/lib/services/dummy_json_service.dart
+++ b/lib/services/dummy_json_service.dart
@@ -8,8 +8,13 @@ class DummyJsonService {
 
   /// Fetches a list of products from the DummyJSON API and converts them to
   /// [Product] objects used by the app.
-  static Future<List<Product>> fetchProducts() async {
-    final response = await http.get(Uri.parse('$_baseUrl/products'));
+  ///
+  /// The [limit] parameter can be used to request a specific number of
+  /// products in a single call. By default it fetches all 194 available
+  /// demo products.
+  static Future<List<Product>> fetchProducts({int limit = 194}) async {
+    final response =
+        await http.get(Uri.parse('$_baseUrl/products?limit=$limit'));
     if (response.statusCode == 200) {
       final Map<String, dynamic> data = jsonDecode(response.body);
       final List<dynamic> products = data['products'] ?? [];


### PR DESCRIPTION
## Summary
- support fetch limit in `DummyJsonService`
- load all 194 products in `CartCubit`
- shrink the product tile width and image size

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888295f3c608321af28c559360ec246