### PR TITLE
Make product grid smaller

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -161,7 +161,8 @@ class _HomePageState extends State<HomePage> {
                   child: GridView.builder(
                     padding: const EdgeInsets.all(12),
                     gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 3,
+                      // Show more items by making each grid tile smaller
+                      crossAxisCount: 4,
                       mainAxisSpacing: 12,
                       crossAxisSpacing: 12,
                       childAspectRatio: 0.65,


### PR DESCRIPTION
## Summary
- show more items in product grid by setting crossAxisCount to 4

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882b096ab483218c6d0391c24b5935