### PR TITLE
Adjust grid to show six items per row

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -161,8 +161,8 @@ class _HomePageState extends State<HomePage> {
                   child: GridView.builder(
                     padding: const EdgeInsets.all(12),
                     gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                      // Show more items by making each grid tile smaller
-                      crossAxisCount: 4,
+                      // Display smaller tiles so six items fit per row
+                      crossAxisCount: 6,
                       mainAxisSpacing: 12,
                       crossAxisSpacing: 12,
                       childAspectRatio: 0.65,


### PR DESCRIPTION
## Summary
- update home page grid settings to fit six products per row

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882c101a188321833f99aaa5893c4c