### PR TITLE
Add product detail view, wishlist, and stock tracking

### DIFF
--- a/lib/cubits/cart_cubit.dart
+++ b/lib/cubits/cart_cubit.dart
@@ -7,22 +7,26 @@ class CartState {
   final List<Product> productShop;
   final List<Product> userCart;
   final List<Product> savedForLater;
+  final List<Product> wishlist;
 
   const CartState({
     this.productShop = const [],
     this.userCart = const [],
     this.savedForLater = const [],
+    this.wishlist = const [],
   });
 
   CartState copyWith({
     List<Product>? productShop,
     List<Product>? userCart,
     List<Product>? savedForLater,
+    List<Product>? wishlist,
   }) {
     return CartState(
       productShop: productShop ?? this.productShop,
       userCart: userCart ?? this.userCart,
       savedForLater: savedForLater ?? this.savedForLater,
+      wishlist: wishlist ?? this.wishlist,
     );
   }
 }
@@ -50,8 +54,11 @@ class CartCubit extends Cubit<CartState> {
     emit(state.copyWith(productShop: allProducts));
   }
 
-  void addItemToCart(Product product) {
-    final updatedCart = List<Product>.from(state.userCart)..add(product);
+  void addItemToCart(Product product, {int quantity = 1}) {
+    if (product.stock < quantity) return;
+    final updatedCart = List<Product>.from(state.userCart)
+      ..addAll(List.filled(quantity, product));
+    product.stock -= quantity;
     emit(state.copyWith(userCart: updatedCart));
   }
 
@@ -79,6 +86,17 @@ class CartCubit extends Cubit<CartState> {
   void removeItemFromSaved(Product product) {
     final saved = List<Product>.from(state.savedForLater)..remove(product);
     emit(state.copyWith(savedForLater: saved));
+  }
+
+  void addItemToWishlist(Product product) {
+    final list = List<Product>.from(state.wishlist);
+    if (!list.contains(product)) list.add(product);
+    emit(state.copyWith(wishlist: list));
+  }
+
+  void removeItemFromWishlist(Product product) {
+    final list = List<Product>.from(state.wishlist)..remove(product);
+    emit(state.copyWith(wishlist: list));
   }
 
   void addProductToShop(Product product) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,11 +5,14 @@ import 'utils/go_router_refresh_stream.dart';
 
 import 'cubits/cart_cubit.dart';
 import 'cubits/auth_cubit.dart';
+import 'models/product.dart';
 import 'pages/intro_page.dart';
 import 'pages/home_page.dart';
 import 'pages/login_page.dart';
 import 'pages/admin_page.dart';
 import 'pages/cart_page.dart';
+import 'pages/product_detail_page.dart';
+import 'pages/wishlist_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -47,6 +50,16 @@ class MyApp extends StatelessWidget {
               GoRoute(
                 path: '/cart',
                 builder: (context, state) => const CartPage(),
+              ),
+              GoRoute(
+                path: '/product',
+                builder: (context, state) => ProductDetailPage(
+                  product: state.extra as Product,
+                ),
+              ),
+              GoRoute(
+                path: '/wishlist',
+                builder: (context, state) => const WishlistPage(),
               ),
               GoRoute(
                 path: '/admin',

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -5,6 +5,7 @@ class Product {
   String description;
   String category;
   bool isDraft;
+  int stock;
 
   /// Basic product model used throughout the app.
   Product({
@@ -12,6 +13,7 @@ class Product {
     required this.price,
     required this.description,
     required this.imagePath,
+    this.stock = 0,
     this.category = 'General',
     this.isDraft = false,
   });

--- a/lib/pages/admin_page.dart
+++ b/lib/pages/admin_page.dart
@@ -25,6 +25,7 @@ class _AdminPageState extends State<AdminPage> {
       price: _price.text,
       description: _description.text,
       imagePath: _image.text,
+      stock: 10,
       isDraft: _draft,
     );
     cubit.addProductToShop(product);

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -35,7 +35,16 @@ class _HomePageState extends State<HomePage> {
   }
 
   void _addToCart(Product product) {
-    context.read<CartCubit>().addItemToCart(product);
+    if (product.stock > 0) {
+      context.read<CartCubit>().addItemToCart(product);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Producto agregado')),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Sin stock')),
+      );
+    }
   }
 
   void _openCart() {
@@ -90,12 +99,12 @@ class _HomePageState extends State<HomePage> {
               icon: const Icon(Icons.admin_panel_settings),
               onPressed: () => context.push('/admin'),
             ),
-          Stack(
-            children: [
-              IconButton(
-                icon: const Icon(Icons.shopping_cart),
-                onPressed: _openCart,
-              ),
+            Stack(
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.shopping_cart),
+                  onPressed: _openCart,
+                ),
               if (cartCount > 0)
                 Positioned(
                   right: 6,
@@ -115,6 +124,10 @@ class _HomePageState extends State<HomePage> {
                   ),
                 ),
             ],
+          ),
+          IconButton(
+            icon: const Icon(Icons.favorite),
+            onPressed: () => context.push('/wishlist'),
           ),
         ],
       ),
@@ -170,12 +183,14 @@ class _HomePageState extends State<HomePage> {
                     itemCount: products.length,
                     itemBuilder: (context, index) {
                       final product = products[index];
-                      return Container(
-                        decoration: BoxDecoration(
-                          color: Colors.grey[100],
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: Column(
+                      return GestureDetector(
+                        onTap: () => context.push('/product', extra: product),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: Colors.grey[100],
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Column(
                           crossAxisAlignment: CrossAxisAlignment.stretch,
                           children: [
                             Expanded(

--- a/lib/pages/product_detail_page.dart
+++ b/lib/pages/product_detail_page.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../cubits/cart_cubit.dart';
+import '../models/product.dart';
+
+class ProductDetailPage extends StatefulWidget {
+  final Product product;
+  const ProductDetailPage({super.key, required this.product});
+
+  @override
+  State<ProductDetailPage> createState() => _ProductDetailPageState();
+}
+
+class _ProductDetailPageState extends State<ProductDetailPage> {
+  int _quantity = 1;
+
+  @override
+  Widget build(BuildContext context) {
+    final product = widget.product;
+    return Scaffold(
+      appBar: AppBar(title: Text(product.name)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: product.imagePath.startsWith('http')
+                  ? Image.network(product.imagePath)
+                  : Image.asset(product.imagePath),
+            ),
+            const SizedBox(height: 10),
+            Text(product.description),
+            const SizedBox(height: 10),
+            Text('RD\$ ${product.price}',
+                style:
+                    const TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
+            const SizedBox(height: 10),
+            Text('Stock: ${product.stock}'),
+            const SizedBox(height: 10),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                IconButton(
+                  onPressed: _quantity > 1
+                      ? () => setState(() => _quantity--)
+                      : null,
+                  icon: const Icon(Icons.remove),
+                ),
+                Text('$_quantity'),
+                IconButton(
+                  onPressed: _quantity < product.stock
+                      ? () => setState(() => _quantity++)
+                      : null,
+                  icon: const Icon(Icons.add),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              onPressed: product.stock > 0
+                  ? () {
+                      context
+                          .read<CartCubit>()
+                          .addItemToCart(product, quantity: _quantity);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Añadido al carrito')),
+                      );
+                      setState(() => _quantity = 1);
+                    }
+                  : null,
+              child: const Text('Agregar al carrito'),
+            ),
+            TextButton(
+              onPressed: () {
+                context.read<CartCubit>().addItemToWishlist(product);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Añadido a wishlist')),
+                );
+              },
+              child: const Text('Agregar a wishlist'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/shop_page.dart
+++ b/lib/pages/shop_page.dart
@@ -16,16 +16,24 @@ class _ShopPageState extends State<ShopPage> {
   bool _isLoading = true;
 
   //adding product to cart method
-  void addProductToCart(Product product)
-  {
-    context.read<CartCubit>().addItemToCart(product);
-
-//alert added successfully
-showDialog(context: context, builder:(context) => AlertDialog(
-  title: Text('Successfully added!'),
-  content: Text('Check your cart'),
-),
-);
+  void addProductToCart(Product product) {
+    if (product.stock > 0) {
+      context.read<CartCubit>().addItemToCart(product);
+      showDialog(
+        context: context,
+        builder: (context) => const AlertDialog(
+          title: Text('Successfully added!'),
+          content: Text('Check your cart'),
+        ),
+      );
+    } else {
+      showDialog(
+        context: context,
+        builder: (context) => const AlertDialog(
+          title: Text('Sin stock'),
+        ),
+      );
+    }
   }
 
   @override
@@ -84,8 +92,12 @@ showDialog(context: context, builder:(context) => AlertDialog(
           Product product = state.productShop[index];
 
           //return product
-          return ProductTile(product: product,
-          onTap: () => addProductToCart(product),
+          return GestureDetector(
+            onTap: () => context.push('/product', extra: product),
+            child: ProductTile(
+              product: product,
+              onTap: () => addProductToCart(product),
+            ),
           );
 
         },

--- a/lib/pages/wishlist_page.dart
+++ b/lib/pages/wishlist_page.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../cubits/cart_cubit.dart';
+import '../components/cart_item.dart';
+
+class WishlistPage extends StatelessWidget {
+  const WishlistPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Wishlist'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: BlocBuilder<CartCubit, CartState>(
+        builder: (context, state) {
+          final items = state.wishlist;
+          if (items.isEmpty) {
+            return const Center(child: Text('No hay productos'));
+          }
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: items
+                .map((p) => CartItem(product: p))
+                .toList(),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/dummy_json_service.dart
+++ b/lib/services/dummy_json_service.dart
@@ -24,6 +24,7 @@ class DummyJsonService {
                 price: item['price'].toString(),
                 description: item['description'] ?? '',
                 imagePath: item['thumbnail'] ?? '',
+                stock: item['stock'] ?? 0,
                 category: item['category'] ?? 'General',
                 isDraft: false,
               ))

--- a/lib/services/fake_store_api.dart
+++ b/lib/services/fake_store_api.dart
@@ -18,6 +18,7 @@ class FakeStoreApi {
                 price: item['price'].toString(),
                 description: item['description'] ?? '',
                 imagePath: item['image'] ?? '',
+                stock: 10,
                 category: item['category'] ?? 'General',
                 isDraft: false,
               ))


### PR DESCRIPTION
## Summary
- extend `Product` with `stock`
- support wishlist and quantity in `CartCubit`
- add product detail and wishlist pages
- show wishlist icon and open detail view from home and shop pages
- add routes for new pages and handle quantity when adding to cart
- include stock when adding products from admin panel

## Testing
- `dart format -o none -l 120 \`git ls-files '*.dart'`` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882e2dcb5c8321a0ea1200ebf79a9f