### PR TITLE
Actualizar vista de artículo y descontar stock tras compra

### DIFF
--- a/lib/cubits/cart_cubit.dart
+++ b/lib/cubits/cart_cubit.dart
@@ -55,11 +55,23 @@ class CartCubit extends Cubit<CartState> {
   }
 
   void addItemToCart(Product product, {int quantity = 1}) {
-    if (product.stock < quantity) return;
-    final updatedCart = List<Product>.from(state.userCart)
-      ..addAll(List.filled(quantity, product));
-    product.stock -= quantity;
-    emit(state.copyWith(userCart: updatedCart));
+    final cart = List<Product>.from(state.userCart);
+    final currentQuantity =
+        cart.where((p) => identical(p, product)).length;
+    if (product.stock < currentQuantity + quantity) return;
+    cart.addAll(List.filled(quantity, product));
+    emit(state.copyWith(userCart: cart));
+  }
+
+  void completePurchase() {
+    final counts = <Product, int>{};
+    for (final p in state.userCart) {
+      counts[p] = (counts[p] ?? 0) + 1;
+    }
+    counts.forEach((product, qty) {
+      product.stock -= qty;
+    });
+    emit(state.copyWith(userCart: []));
   }
 
   void saveItemForLater(Product product) {

--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -66,7 +66,7 @@ class CartPage extends StatelessWidget {
               onPressed: () async {
                 final success = await PaymentService.processPayment(items);
                 if (success) {
-                  context.read<CartCubit>().clearCart();
+                  context.read<CartCubit>().completePurchase();
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('Pago completado')),
                   );

--- a/lib/pages/product_detail_page.dart
+++ b/lib/pages/product_detail_page.dart
@@ -20,66 +20,80 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
     final product = widget.product;
     return Scaffold(
       appBar: AppBar(title: Text(product.name)),
-      body: Padding(
+      body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Expanded(
-              child: product.imagePath.startsWith('http')
-                  ? Image.network(product.imagePath)
-                  : Image.asset(product.imagePath),
-            ),
-            const SizedBox(height: 10),
-            Text(product.description),
-            const SizedBox(height: 10),
-            Text('RD\$ ${product.price}',
-                style:
-                    const TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
-            const SizedBox(height: 10),
-            Text('Stock: ${product.stock}'),
-            const SizedBox(height: 10),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                IconButton(
-                  onPressed: _quantity > 1
-                      ? () => setState(() => _quantity--)
-                      : null,
-                  icon: const Icon(Icons.remove),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    SizedBox(
+                      height: 250,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: product.imagePath.startsWith('http')
+                            ? Image.network(product.imagePath, fit: BoxFit.cover)
+                            : Image.asset(product.imagePath, fit: BoxFit.cover),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(product.description),
+                    const SizedBox(height: 10),
+                    Text('RD\$ ${product.price}',
+                        style: const TextStyle(
+                            fontWeight: FontWeight.bold, fontSize: 20)),
+                    const SizedBox(height: 10),
+                    Text('Stock: ${product.stock}'),
+                    const SizedBox(height: 10),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        IconButton(
+                          onPressed: _quantity > 1
+                              ? () => setState(() => _quantity--)
+                              : null,
+                          icon: const Icon(Icons.remove),
+                        ),
+                        Text('$_quantity'),
+                        IconButton(
+                          onPressed: _quantity < product.stock
+                              ? () => setState(() => _quantity++)
+                              : null,
+                          icon: const Icon(Icons.add),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    ElevatedButton(
+                      onPressed: product.stock > 0
+                          ? () {
+                              context
+                                  .read<CartCubit>()
+                                  .addItemToCart(product, quantity: _quantity);
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Añadido al carrito')),
+                              );
+                              setState(() => _quantity = 1);
+                            }
+                          : null,
+                      child: const Text('Agregar al carrito'),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        context.read<CartCubit>().addItemToWishlist(product);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Añadido a wishlist')),
+                        );
+                      },
+                      child: const Text('Agregar a wishlist'),
+                    ),
+                  ],
                 ),
-                Text('$_quantity'),
-                IconButton(
-                  onPressed: _quantity < product.stock
-                      ? () => setState(() => _quantity++)
-                      : null,
-                  icon: const Icon(Icons.add),
-                ),
-              ],
-            ),
-            const SizedBox(height: 10),
-            ElevatedButton(
-              onPressed: product.stock > 0
-                  ? () {
-                      context
-                          .read<CartCubit>()
-                          .addItemToCart(product, quantity: _quantity);
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('Añadido al carrito')),
-                      );
-                      setState(() => _quantity = 1);
-                    }
-                  : null,
-              child: const Text('Agregar al carrito'),
-            ),
-            TextButton(
-              onPressed: () {
-                context.read<CartCubit>().addItemToWishlist(product);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Añadido a wishlist')),
-                );
-              },
-              child: const Text('Agregar a wishlist'),
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
## Resumen
- mejorar la vista de la página de detalles usando `Card` y `SingleChildScrollView`
- evitar que el stock se descuente al agregar al carrito
- descontar el stock cuando el pago es exitoso

## Testing
- `flutter test` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6888313022e4832180c39905f9999a81