### PR TITLE
Fix missing ')' in home page

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -262,8 +262,9 @@ class _HomePageState extends State<HomePage> {
                             const SizedBox(height: 8),
                           ],
                         ),
-                      );
-                    },
+                      ),
+                    );
+                  },
                   ),
                 ),
               ],


### PR DESCRIPTION
## Summary
- close `GestureDetector` properly in `home_page.dart`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888347867108321a94741f05a43127e