### PR TITLE
Improve cart quantity display and image sizes

### DIFF
--- a/lib/components/cart_item.dart
+++ b/lib/components/cart_item.dart
@@ -7,7 +7,13 @@ import '../cubits/cart_cubit.dart';
 class CartItem extends StatelessWidget {
   final Product product;
   final bool isSavedItem;
-  const CartItem({super.key, required this.product, this.isSavedItem = false});
+  final int quantity;
+  const CartItem({
+    super.key,
+    required this.product,
+    this.isSavedItem = false,
+    this.quantity = 1,
+  });
 
   void _remove(BuildContext context) {
     if (isSavedItem) {
@@ -34,11 +40,21 @@ class CartItem extends StatelessWidget {
       ),
       margin: const EdgeInsets.only(bottom: 10),
       child: ListTile(
-        leading: product.imagePath.startsWith('http')
-            ? Image.network(product.imagePath)
-            : Image.asset(product.imagePath),
+          leading: product.imagePath.startsWith('http')
+              ? Image.network(
+                  product.imagePath,
+                  width: 60,
+                  height: 60,
+                  fit: BoxFit.cover,
+                )
+              : Image.asset(
+                  product.imagePath,
+                  width: 60,
+                  height: 60,
+                  fit: BoxFit.cover,
+                ),
         title: Text(product.name),
-        subtitle: Text(product.price),
+        subtitle: Text('${product.price} - Cantidad: $quantity'),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -25,6 +25,10 @@ class CartPage extends StatelessWidget {
         builder: (context, state) {
           final items = state.userCart;
           final saved = state.savedForLater;
+          final counts = <Product, int>{};
+          for (final p in items) {
+            counts[p] = (counts[p] ?? 0) + 1;
+          }
           return Padding(
             padding: const EdgeInsets.symmetric(horizontal: 25.0),
             child: ListView(
@@ -38,7 +42,7 @@ class CartPage extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 15),
-                ...items.map((p) => CartItem(product: p)).toList(),
+                ...counts.entries.map((e) => CartItem(product: e.key, quantity: e.value)).toList(),
                 const SizedBox(height: 20),
                 if (saved.isNotEmpty) ...[
                   Text(

--- a/lib/pages/product_detail_page.dart
+++ b/lib/pages/product_detail_page.dart
@@ -36,14 +36,14 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                       child: product.imagePath.startsWith('http')
                           ? Image.network(
                               product.imagePath,
-                              width: 120,
-                              height: 120,
+                              width: 180,
+                              height: 180,
                               fit: BoxFit.cover,
                             )
                           : Image.asset(
                               product.imagePath,
-                              width: 120,
-                              height: 120,
+                              width: 180,
+                              height: 180,
                               fit: BoxFit.cover,
                             ),
                     ),


### PR DESCRIPTION
## Summary
- display quantity per item instead of duplicates in cart
- enlarge product detail image and cart item images

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888366b99508321b650bfd689fbb458