### PR TITLE
Fix missing import in CartPage

### DIFF
--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -6,6 +6,7 @@ import '../components/cart_item.dart';
 import '../cubits/cart_cubit.dart';
 import '../services/payment_service.dart';
 import '../cubits/auth_cubit.dart';
+import '../models/product.dart';
 import 'login_page.dart';
 
 class CartPage extends StatelessWidget {


### PR DESCRIPTION
## Summary
- add missing `Product` model import in `CartPage`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688837b299d883218f4acdb6bb614ed4