### PR TITLE
Add Spanish translations and navigation drawer

### DIFF
--- a/lib/components/app_drawer.dart
+++ b/lib/components/app_drawer.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../cubits/auth_cubit.dart';
+
+class AppDrawer extends StatelessWidget {
+  const AppDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final authState = context.watch<AuthCubit>().state;
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: [
+          DrawerHeader(
+            decoration: BoxDecoration(color: Theme.of(context).primaryColor),
+            child: const Text(
+              'ShoppingRD',
+              style: TextStyle(color: Colors.white, fontSize: 24),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.home),
+            title: const Text('Inicio'),
+            onTap: () => context.go('/home'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.shopping_cart),
+            title: const Text('Carrito'),
+            onTap: () => context.go('/cart'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.favorite),
+            title: const Text('Lista de deseos'),
+            onTap: () => context.go('/wishlist'),
+          ),
+          if (authState.isAdmin)
+            ListTile(
+              leading: const Icon(Icons.admin_panel_settings),
+              title: const Text('Admin'),
+              onTap: () => context.go('/admin'),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/admin_page.dart
+++ b/lib/pages/admin_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../models/product.dart';
 import '../cubits/cart_cubit.dart';
+import '../components/app_drawer.dart';
 
 class AdminPage extends StatefulWidget {
   const AdminPage({super.key});
@@ -41,7 +42,8 @@ class _AdminPageState extends State<AdminPage> {
     final cubit = context.read<CartCubit>();
     final cart = context.watch<CartCubit>().state;
     return Scaffold(
-      appBar: AppBar(title: const Text('Admin Panel')),
+      drawer: const AppDrawer(),
+      appBar: AppBar(title: const Text('Panel de Administración')),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: SingleChildScrollView(
@@ -49,29 +51,29 @@ class _AdminPageState extends State<AdminPage> {
             children: [
               TextField(
                 controller: _name,
-                decoration: const InputDecoration(labelText: 'Name'),
+                decoration: const InputDecoration(labelText: 'Nombre'),
               ),
               TextField(
                 controller: _price,
-                decoration: const InputDecoration(labelText: 'Price'),
+                decoration: const InputDecoration(labelText: 'Precio'),
               ),
               TextField(
                 controller: _description,
-                decoration: const InputDecoration(labelText: 'Description'),
+                decoration: const InputDecoration(labelText: 'Descripción'),
               ),
               TextField(
                 controller: _image,
-                decoration: const InputDecoration(labelText: 'Image URL'),
+                decoration: const InputDecoration(labelText: 'URL de imagen'),
               ),
               SwitchListTile(
-                title: const Text('Draft'),
+                title: const Text('Borrador'),
                 value: _draft,
                 onChanged: (value) => setState(() => _draft = value),
               ),
               const SizedBox(height: 10),
               ElevatedButton(
                 onPressed: _addProduct,
-                child: const Text('Add Product'),
+                child: const Text('Agregar Producto'),
               ),
               const SizedBox(height: 20),
               ListView.builder(

--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -8,6 +8,7 @@ import '../services/payment_service.dart';
 import '../cubits/auth_cubit.dart';
 import '../models/product.dart';
 import 'login_page.dart';
+import '../components/app_drawer.dart';
 
 class CartPage extends StatelessWidget {
   const CartPage({super.key});
@@ -15,6 +16,7 @@ class CartPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(
         title: const Text('Mi Carrito'),
         leading: IconButton(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -5,6 +5,7 @@ import '../models/product.dart';
 import 'login_page.dart';
 import '../cubits/auth_cubit.dart';
 import 'package:go_router/go_router.dart';
+import '../components/app_drawer.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -104,6 +105,7 @@ class _HomePageState extends State<HomePage> {
     final authState = context.watch<AuthCubit>().state;
 
     return Scaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(
         title: const Text('ShoppingRD'),
         centerTitle: false,

--- a/lib/pages/intro_page.dart
+++ b/lib/pages/intro_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
+import '../components/app_drawer.dart';
 
 class IntroPage extends StatelessWidget {
   const IntroPage({super.key});
@@ -8,6 +9,7 @@ class IntroPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      drawer: const AppDrawer(),
       backgroundColor: Colors.grey[300],
       body: Center(
         child: Padding(

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 import '../cubits/auth_cubit.dart';
+import '../components/app_drawer.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -26,14 +27,15 @@ class _LoginPageState extends State<LoginPage> {
     if (success) {
       context.go('/home');
     } else {
-      setState(() => _error = 'Invalid credentials');
+      setState(() => _error = 'Credenciales inválidas');
     }
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Login')),
+      drawer: const AppDrawer(),
+      appBar: AppBar(title: const Text('Iniciar Sesión')),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -41,12 +43,12 @@ class _LoginPageState extends State<LoginPage> {
           children: [
             TextField(
               controller: _emailController,
-              decoration: const InputDecoration(labelText: 'Email'),
+              decoration: const InputDecoration(labelText: 'Correo electrónico'),
             ),
             const SizedBox(height: 12),
             TextField(
               controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'Password'),
+              decoration: const InputDecoration(labelText: 'Contraseña'),
               obscureText: true,
             ),
             if (_error != null) ...[
@@ -56,7 +58,7 @@ class _LoginPageState extends State<LoginPage> {
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: _submit,
-              child: const Text('Login'),
+              child: const Text('Ingresar'),
             ),
           ],
         ),

--- a/lib/pages/product_detail_page.dart
+++ b/lib/pages/product_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../cubits/cart_cubit.dart';
 import '../models/product.dart';
+import '../components/app_drawer.dart';
 
 class ProductDetailPage extends StatefulWidget {
   final Product product;
@@ -19,6 +20,7 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
   Widget build(BuildContext context) {
     final product = widget.product;
     return Scaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(title: Text(product.name)),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),

--- a/lib/pages/wishlist_page.dart
+++ b/lib/pages/wishlist_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../cubits/cart_cubit.dart';
 import '../components/cart_item.dart';
+import '../components/app_drawer.dart';
 
 class WishlistPage extends StatelessWidget {
   const WishlistPage({super.key});
@@ -11,8 +12,9 @@ class WishlistPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      drawer: const AppDrawer(),
       appBar: AppBar(
-        title: const Text('Wishlist'),
+        title: const Text('Lista de deseos'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () => context.pop(),

--- a/lib/services/fake_store_api.dart
+++ b/lib/services/fake_store_api.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:translator/translator.dart';
 import '../models/product.dart';
 
 /// Service class for interacting with the Fake Store API.
@@ -11,18 +12,27 @@ class FakeStoreApi {
   static Future<List<Product>> fetchProducts() async {
     final response = await http.get(Uri.parse('$_baseUrl/products'));
     if (response.statusCode == 200) {
+      final translator = GoogleTranslator();
       final List<dynamic> data = jsonDecode(response.body);
-      return data
-          .map((item) => Product(
-                name: item['title'] ?? 'Unknown',
-                price: item['price'].toString(),
-                description: item['description'] ?? '',
-                imagePath: item['image'] ?? '',
-                stock: 10,
-                category: item['category'] ?? 'General',
-                isDraft: false,
-              ))
-          .toList();
+      final List<Product> products = [];
+      for (final item in data) {
+        final name = item['title'] ?? 'Unknown';
+        final description = item['description'] ?? '';
+        final translatedName = await translator.translate(name, to: 'es');
+        final translatedDesc = await translator.translate(description, to: 'es');
+        products.add(
+          Product(
+            name: translatedName.text,
+            price: item['price'].toString(),
+            description: translatedDesc.text,
+            imagePath: item['image'] ?? '',
+            stock: 10,
+            category: item['category'] ?? 'General',
+            isDraft: false,
+          ),
+        );
+      }
+      return products;
     } else {
       throw Exception('Failed to load products');
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   flutter_bloc: ^8.1.3
   go_router: ^13.0.0
   http: ^0.13.6
+  translator: ^0.1.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a new `AppDrawer` widget with links to main pages
- integrate drawer into all pages
- translate admin and login pages to Spanish
- ensure fetched product names and descriptions are translated using the `translator` package
- add translator dependency in `pubspec.yaml`

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688839c408088321859ee8853932b109