### PR TITLE
Fix translator dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   flutter_bloc: ^8.1.3
   go_router: ^13.0.0
   http: ^0.13.6
-  translator: ^0.1.8
+  translator: ^0.1.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- correct translator version to `^0.1.7`

## Testing
- `flutter test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68883c9a236c832182e02835958d660c