### PR TITLE
Add header navigation

### DIFF
--- a/lib/components/app_header.dart
+++ b/lib/components/app_header.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../cubits/cart_cubit.dart';
+import '../cubits/auth_cubit.dart';
+
+class AppHeader extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final bool showBack;
+
+  const AppHeader({super.key, required this.title, this.showBack = false});
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    final cartState = context.watch<CartCubit>().state;
+    final authState = context.watch<AuthCubit>().state;
+    final cartCount = cartState.userCart.length;
+
+    return AppBar(
+      leading: IconButton(
+        icon: Icon(showBack ? Icons.arrow_back : Icons.home),
+        onPressed: () {
+          if (showBack) {
+            context.pop();
+          } else {
+            context.go('/home');
+          }
+        },
+      ),
+      title: Text(title),
+      actions: [
+        Stack(
+          children: [
+            IconButton(
+              icon: const Icon(Icons.shopping_cart),
+              onPressed: () => context.go('/cart'),
+            ),
+            if (cartCount > 0)
+              Positioned(
+                right: 6,
+                top: 6,
+                child: Container(
+                  padding: const EdgeInsets.all(2),
+                  decoration: const BoxDecoration(
+                    color: Colors.red,
+                    shape: BoxShape.circle,
+                  ),
+                  constraints: const BoxConstraints(minWidth: 16, minHeight: 16),
+                  child: Text(
+                    '$cartCount',
+                    style: const TextStyle(color: Colors.white, fontSize: 10),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
+          ],
+        ),
+        IconButton(
+          icon: const Icon(Icons.favorite),
+          onPressed: () => context.go('/wishlist'),
+        ),
+        if (authState.isAdmin)
+          IconButton(
+            icon: const Icon(Icons.admin_panel_settings),
+            onPressed: () => context.go('/admin'),
+          ),
+        if (authState.isLoggedIn)
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () {
+              context.read<AuthCubit>().logout();
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Sesión cerrada')),
+              );
+            },
+          )
+        else
+          IconButton(
+            icon: const Icon(Icons.login),
+            onPressed: () => context.go('/login'),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/pages/admin_page.dart
+++ b/lib/pages/admin_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../models/product.dart';
 import '../cubits/cart_cubit.dart';
+import '../components/app_header.dart';
 
 class AdminPage extends StatefulWidget {
   const AdminPage({super.key});
@@ -41,7 +42,7 @@ class _AdminPageState extends State<AdminPage> {
     final cubit = context.read<CartCubit>();
     final cart = context.watch<CartCubit>().state;
     return Scaffold(
-      appBar: AppBar(title: const Text('Panel de Administración')),
+      appBar: const AppHeader(title: 'Panel de Administración', showBack: true),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: SingleChildScrollView(

--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
+import '../components/app_header.dart';
+
 import '../components/cart_item.dart';
 import '../cubits/cart_cubit.dart';
 import '../services/payment_service.dart';
@@ -15,13 +17,7 @@ class CartPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Mi Carrito'),
-        leading: IconButton(
-          icon: const Icon(Icons.home),
-          onPressed: () => context.pop(),
-        ),
-      ),
+      appBar: const AppHeader(title: 'Mi Carrito', showBack: true),
       body: BlocBuilder<CartCubit, CartState>(
         builder: (context, state) {
           final items = state.userCart;
@@ -63,24 +59,22 @@ class CartPage extends StatelessWidget {
           );
         },
       ),
-      bottomNavigationBar: BlocBuilder<CartCubit, CartState>(
+      floatingActionButton: BlocBuilder<CartCubit, CartState>(
         builder: (context, state) {
           final items = state.userCart;
           if (items.isEmpty) return const SizedBox.shrink();
-          return Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: ElevatedButton(
-              onPressed: () async {
-                final auth = context.read<AuthCubit>();
-                if (!auth.state.isLoggedIn) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Inicia sesión para comprar')),
-                  );
-                  await Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const LoginPage()),
-                  );
-                  return;
-                }
+          return FloatingActionButton.extended(
+            onPressed: () async {
+              final auth = context.read<AuthCubit>();
+              if (!auth.state.isLoggedIn) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Inicia sesión para comprar')),
+                );
+                await Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const LoginPage()),
+                );
+                return;
+              }
 
                 final address = await showDialog<String>(
                   context: context,
@@ -123,9 +117,8 @@ class CartPage extends StatelessWidget {
                   );
                 }
               },
-              child: const Text('Pagar'),
-            ),
-          );
+              label: const Text('Pagar'),
+            );
         },
       ),
     );

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -5,6 +5,7 @@ import '../models/product.dart';
 import 'login_page.dart';
 import '../cubits/auth_cubit.dart';
 import 'package:go_router/go_router.dart';
+import '../components/app_header.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -78,10 +79,6 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  void _openCart() {
-    context.push('/cart');
-  }
-
   @override
   void dispose() {
     _searchController.dispose();
@@ -104,64 +101,7 @@ class _HomePageState extends State<HomePage> {
     final authState = context.watch<AuthCubit>().state;
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('ShoppingRD'),
-        centerTitle: false,
-        actions: [
-          if (authState.isLoggedIn)
-            IconButton(
-              icon: const Icon(Icons.logout),
-              onPressed: () {
-                context.read<AuthCubit>().logout();
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Sesión cerrada')),
-                );
-              },
-            )
-          else
-            IconButton(
-              icon: const Icon(Icons.login),
-              onPressed: () => Navigator.of(context).push(
-                MaterialPageRoute(builder: (_) => const LoginPage()),
-              ),
-            ),
-          if (authState.isAdmin)
-            IconButton(
-              icon: const Icon(Icons.admin_panel_settings),
-              onPressed: () => context.push('/admin'),
-            ),
-            Stack(
-              children: [
-                IconButton(
-                  icon: const Icon(Icons.shopping_cart),
-                  onPressed: _openCart,
-                ),
-              if (cartCount > 0)
-                Positioned(
-                  right: 6,
-                  top: 6,
-                  child: Container(
-                    padding: const EdgeInsets.all(2),
-                    decoration: const BoxDecoration(
-                      color: Colors.red,
-                      shape: BoxShape.circle,
-                    ),
-                    constraints: const BoxConstraints(minWidth: 16, minHeight: 16),
-                    child: Text(
-                      '$cartCount',
-                      style: const TextStyle(color: Colors.white, fontSize: 10),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                ),
-            ],
-          ),
-          IconButton(
-            icon: const Icon(Icons.favorite),
-            onPressed: () => context.push('/wishlist'),
-          ),
-        ],
-      ),
+      appBar: const AppHeader(title: 'ShoppingRD'),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : Column(

--- a/lib/pages/intro_page.dart
+++ b/lib/pages/intro_page.dart
@@ -2,12 +2,15 @@ import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
 
+import '../components/app_header.dart';
+
 class IntroPage extends StatelessWidget {
   const IntroPage({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: const AppHeader(title: 'Bienvenido'),
       backgroundColor: Colors.grey[300],
       body: Center(
         child: Padding(

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
+import '../components/app_header.dart';
+
 import '../cubits/auth_cubit.dart';
 
 class LoginPage extends StatefulWidget {
@@ -33,7 +35,7 @@ class _LoginPageState extends State<LoginPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Iniciar Sesión')),
+      appBar: const AppHeader(title: 'Iniciar Sesión', showBack: true),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/lib/pages/product_detail_page.dart
+++ b/lib/pages/product_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../cubits/cart_cubit.dart';
 import '../models/product.dart';
+import '../components/app_header.dart';
 
 class ProductDetailPage extends StatefulWidget {
   final Product product;
@@ -19,7 +20,7 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
   Widget build(BuildContext context) {
     final product = widget.product;
     return Scaffold(
-      appBar: AppBar(title: Text(product.name)),
+      appBar: AppHeader(title: product.name, showBack: true),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/lib/pages/wishlist_page.dart
+++ b/lib/pages/wishlist_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
+import '../components/app_header.dart';
+
 import '../cubits/cart_cubit.dart';
 import '../components/cart_item.dart';
 
@@ -11,13 +13,7 @@ class WishlistPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Lista de deseos'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
-        ),
-      ),
+      appBar: const AppHeader(title: 'Lista de deseos', showBack: true),
       body: BlocBuilder<CartCubit, CartState>(
         builder: (context, state) {
           final items = state.wishlist;


### PR DESCRIPTION
## Summary
- introduce `AppHeader` component to centralize navigation in app bar
- replace page-specific `AppBar`s with new header
- remove bottom navigation and switch cart to a floating action button

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format lib/pages/*.dart lib/components/*.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68883f429104832181e31aac01cab6b2