### PR TITLE
Fix back navigation

### DIFF
--- a/lib/components/app_header.dart
+++ b/lib/components/app_header.dart
@@ -37,7 +37,7 @@ class AppHeader extends StatelessWidget implements PreferredSizeWidget {
           children: [
             IconButton(
               icon: const Icon(Icons.shopping_cart),
-              onPressed: () => context.go('/cart'),
+              onPressed: () => context.push('/cart'),
             ),
             if (cartCount > 0)
               Positioned(
@@ -61,12 +61,12 @@ class AppHeader extends StatelessWidget implements PreferredSizeWidget {
         ),
         IconButton(
           icon: const Icon(Icons.favorite),
-          onPressed: () => context.go('/wishlist'),
+          onPressed: () => context.push('/wishlist'),
         ),
         if (authState.isAdmin)
           IconButton(
             icon: const Icon(Icons.admin_panel_settings),
-            onPressed: () => context.go('/admin'),
+            onPressed: () => context.push('/admin'),
           ),
         if (authState.isLoggedIn)
           IconButton(
@@ -81,7 +81,7 @@ class AppHeader extends StatelessWidget implements PreferredSizeWidget {
         else
           IconButton(
             icon: const Icon(Icons.login),
-            onPressed: () => context.go('/login'),
+            onPressed: () => context.push('/login'),
           ),
       ],
     );


### PR DESCRIPTION
## Summary
- use `context.push` when navigating to cart, wishlist, admin and login pages so
  the back arrow works properly

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888418e83008321b205ce080b3d3adf