### PR TITLE
Add user profile, registration and order history

### DIFF
--- a/lib/components/app_header.dart
+++ b/lib/components/app_header.dart
@@ -68,7 +68,11 @@ class AppHeader extends StatelessWidget implements PreferredSizeWidget {
             icon: const Icon(Icons.admin_panel_settings),
             onPressed: () => context.push('/admin'),
           ),
-        if (authState.isLoggedIn)
+        if (authState.isLoggedIn) ...[
+          IconButton(
+            icon: const Icon(Icons.person),
+            onPressed: () => context.push('/profile'),
+          ),
           IconButton(
             icon: const Icon(Icons.logout),
             onPressed: () {
@@ -77,7 +81,8 @@ class AppHeader extends StatelessWidget implements PreferredSizeWidget {
                 const SnackBar(content: Text('Sesión cerrada')),
               );
             },
-          )
+          ),
+        ]
         else
           IconButton(
             icon: const Icon(Icons.login),

--- a/lib/cubits/auth_cubit.dart
+++ b/lib/cubits/auth_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../models/user.dart';
+import '../models/product.dart';
 
 class AuthState {
   final User? currentUser;
@@ -13,7 +14,7 @@ class AuthState {
 class AuthCubit extends Cubit<AuthState> {
   AuthCubit() : super(const AuthState());
 
-  final List<User> _users = const [
+  final List<User> _users = [
     User(email: 'admin@example.com', password: 'admin123', isAdmin: true),
     User(email: 'user@example.com', password: 'user123'),
   ];
@@ -28,6 +29,30 @@ class AuthCubit extends Cubit<AuthState> {
       return true;
     } catch (_) {
       return false;
+    }
+  }
+
+  bool register(String email, String password, String address) {
+    if (_users.any((u) => u.email == email)) return false;
+    final user = User(email: email, password: password, address: address);
+    _users.add(user);
+    emit(AuthState(currentUser: user));
+    return true;
+  }
+
+  void updateAddress(String address) {
+    final user = state.currentUser;
+    if (user != null) {
+      user.address = address;
+      emit(AuthState(currentUser: user));
+    }
+  }
+
+  void addOrder(List<Product> products) {
+    final user = state.currentUser;
+    if (user != null) {
+      user.orderHistory.addAll(products);
+      emit(AuthState(currentUser: user));
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,10 +9,12 @@ import 'models/product.dart';
 import 'pages/intro_page.dart';
 import 'pages/home_page.dart';
 import 'pages/login_page.dart';
+import 'pages/register_page.dart';
 import 'pages/admin_page.dart';
 import 'pages/cart_page.dart';
 import 'pages/product_detail_page.dart';
 import 'pages/wishlist_page.dart';
+import 'pages/profile_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -40,6 +42,10 @@ class MyApp extends StatelessWidget {
                 builder: (context, state) => const LoginPage(),
               ),
               GoRoute(
+                path: '/register',
+                builder: (context, state) => const RegisterPage(),
+              ),
+              GoRoute(
                 path: '/',
                 builder: (context, state) => const IntroPage(),
               ),
@@ -62,6 +68,10 @@ class MyApp extends StatelessWidget {
                 builder: (context, state) => const WishlistPage(),
               ),
               GoRoute(
+                path: '/profile',
+                builder: (context, state) => const ProfilePage(),
+              ),
+              GoRoute(
                 path: '/admin',
                 builder: (context, state) => const AdminPage(),
               ),
@@ -70,6 +80,8 @@ class MyApp extends StatelessWidget {
               final isAdmin = authState.isAdmin;
               final loc = state.matchedLocation;
               if (loc == '/login' && authState.isLoggedIn) return '/home';
+              if (loc == '/register' && authState.isLoggedIn) return '/home';
+              if (loc == '/profile' && !authState.isLoggedIn) return '/login';
               if (loc == '/admin' && !isAdmin) return '/home';
               return null;
             },

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,7 +1,17 @@
+import 'product.dart';
+
 class User {
   final String email;
   final String password;
   final bool isAdmin;
+  String address;
+  final List<Product> orderHistory;
 
-  const User({required this.email, required this.password, this.isAdmin = false});
+  User({
+    required this.email,
+    required this.password,
+    this.isAdmin = false,
+    this.address = '',
+    List<Product>? orderHistory,
+  }) : orderHistory = orderHistory ?? [];
 }

--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -76,49 +76,29 @@ class CartPage extends StatelessWidget {
                 return;
               }
 
-                final address = await showDialog<String>(
-                  context: context,
-                  builder: (context) {
-                    final controller = TextEditingController();
-                    return AlertDialog(
-                      title: const Text('Dirección de envío'),
-                      content: TextField(
-                        controller: controller,
-                        decoration: const InputDecoration(
-                          hintText: 'Ingresa tu dirección',
-                        ),
-                      ),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.pop(context),
-                          child: const Text('Cancelar'),
-                        ),
-                        ElevatedButton(
-                          onPressed: () =>
-                              Navigator.pop(context, controller.text),
-                          child: const Text('Continuar'),
-                        ),
-                      ],
-                    );
-                  },
+              if (auth.state.currentUser!.address.trim().isEmpty) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Agrega una dirección en tu perfil')),
                 );
+                context.push('/profile');
+                return;
+              }
 
-                if (address == null || address.trim().isEmpty) return;
-
-                final success = await PaymentService.processPayment(items);
-                if (success) {
-                  context.read<CartCubit>().completePurchase();
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Pago completado')),
-                  );
-                } else {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Error al procesar pago')),
-                  );
-                }
-              },
-              label: const Text('Pagar'),
-            );
+              final success = await PaymentService.processPayment(items);
+              if (success) {
+                context.read<AuthCubit>().addOrder(List<Product>.from(items));
+                context.read<CartCubit>().completePurchase();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Pago completado')),
+                );
+              } else {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Error al procesar pago')),
+                );
+              }
+            },
+            label: const Text('Pagar'),
+          );
         },
       ),
     );

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../components/app_header.dart';
+import '../cubits/auth_cubit.dart';
+
+class ProfilePage extends StatefulWidget {
+  const ProfilePage({super.key});
+
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> {
+  late TextEditingController _addressController;
+
+  @override
+  void initState() {
+    super.initState();
+    final user = context.read<AuthCubit>().state.currentUser;
+    _addressController = TextEditingController(text: user?.address ?? '');
+  }
+
+  @override
+  void dispose() {
+    _addressController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    context.read<AuthCubit>().updateAddress(_addressController.text);
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Dirección guardada')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = context.watch<AuthCubit>().state.currentUser;
+    final orders = user?.orderHistory ?? [];
+
+    return Scaffold(
+      appBar: const AppHeader(title: 'Perfil', showBack: true),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            TextField(
+              controller: _addressController,
+              decoration: const InputDecoration(labelText: 'Dirección de envío'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('Guardar'),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              'Historial de compras',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+            ),
+            const SizedBox(height: 10),
+            ...orders.map(
+              (p) => ListTile(
+                title: Text(p.name),
+                subtitle: Text('RD\$ ${p.price}'),
+              ),
+            ),
+            if (orders.isEmpty)
+              const Text('Aún no has realizado compras'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -3,53 +3,62 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 import '../components/app_header.dart';
-
 import '../cubits/auth_cubit.dart';
 
-class LoginPage extends StatefulWidget {
-  const LoginPage({super.key});
+class RegisterPage extends StatefulWidget {
+  const RegisterPage({super.key});
 
   @override
-  State<LoginPage> createState() => _LoginPageState();
+  State<RegisterPage> createState() => _RegisterPageState();
 }
 
-class _LoginPageState extends State<LoginPage> {
-  final TextEditingController _emailController = TextEditingController();
-  final TextEditingController _passwordController = TextEditingController();
+class _RegisterPageState extends State<RegisterPage> {
+  final TextEditingController _email = TextEditingController();
+  final TextEditingController _password = TextEditingController();
+  final TextEditingController _address = TextEditingController();
   String? _error;
 
   void _submit() {
     final auth = context.read<AuthCubit>();
-    if (auth.state.isLoggedIn) {
-      setState(() => _error = 'Ya has iniciado sesión');
-      return;
-    }
-    final success = auth.login(_emailController.text, _passwordController.text);
+    final success = auth.register(_email.text, _password.text, _address.text);
     if (success) {
       context.go('/home');
     } else {
-      setState(() => _error = 'Credenciales inválidas');
+      setState(() => _error = 'El correo ya está en uso');
     }
+  }
+
+  @override
+  void dispose() {
+    _email.dispose();
+    _password.dispose();
+    _address.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: const AppHeader(title: 'Iniciar Sesión', showBack: true),
+      appBar: const AppHeader(title: 'Registrarse', showBack: true),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             TextField(
-              controller: _emailController,
+              controller: _email,
               decoration: const InputDecoration(labelText: 'Correo electrónico'),
             ),
             const SizedBox(height: 12),
             TextField(
-              controller: _passwordController,
+              controller: _password,
               decoration: const InputDecoration(labelText: 'Contraseña'),
               obscureText: true,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _address,
+              decoration: const InputDecoration(labelText: 'Dirección de envío'),
             ),
             if (_error != null) ...[
               const SizedBox(height: 8),
@@ -58,11 +67,7 @@ class _LoginPageState extends State<LoginPage> {
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: _submit,
-              child: const Text('Ingresar'),
-            ),
-            TextButton(
-              onPressed: () => context.push('/register'),
-              child: const Text('Crear nueva cuenta'),
+              child: const Text('Registrarse'),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- extend `User` model with address and order history
- support registration, address updates and order saving in `AuthCubit`
- add profile page to manage shipping address and see past orders
- add registration page
- require a saved address before purchasing
- show profile and register routes and actions

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688843f5dd9c8321b83d8ff6e0b55f32