### PR TITLE
Add extended user profile and login via username

### DIFF
--- a/lib/cubits/auth_cubit.dart
+++ b/lib/cubits/auth_cubit.dart
@@ -15,15 +15,26 @@ class AuthCubit extends Cubit<AuthState> {
   AuthCubit() : super(const AuthState());
 
   final List<User> _users = [
-    User(email: 'admin@example.com', password: 'admin123', isAdmin: true),
-    User(email: 'user@example.com', password: 'user123'),
+    User(
+      email: 'admin@example.com',
+      username: 'admin',
+      password: 'admin123',
+      isAdmin: true,
+      name: 'Administrador',
+    ),
+    User(
+      email: 'user@example.com',
+      username: 'user',
+      password: 'user123',
+      name: 'Usuario',
+    ),
   ];
 
-  bool login(String email, String password) {
+  bool login(String username, String password) {
     if (state.isLoggedIn) return false;
     try {
       final user = _users.firstWhere(
-        (u) => u.email == email && u.password == password,
+        (u) => u.username == username && u.password == password,
       );
       emit(AuthState(currentUser: user));
       return true;
@@ -32,18 +43,46 @@ class AuthCubit extends Cubit<AuthState> {
     }
   }
 
-  bool register(String email, String password, String address) {
-    if (_users.any((u) => u.email == email)) return false;
-    final user = User(email: email, password: password, address: address);
+  bool register({
+    required String email,
+    required String username,
+    required String password,
+    required String name,
+    required String phone,
+    required String street,
+    required String province,
+    required String city,
+  }) {
+    if (_users.any((u) => u.email == email || u.username == username)) return false;
+    final user = User(
+      email: email,
+      username: username,
+      password: password,
+      name: name,
+      phone: phone,
+      street: street,
+      province: province,
+      city: city,
+    );
     _users.add(user);
     emit(AuthState(currentUser: user));
     return true;
   }
 
-  void updateAddress(String address) {
+  void updateProfile({
+    String? name,
+    String? phone,
+    String? street,
+    String? province,
+    String? city,
+  }) {
     final user = state.currentUser;
     if (user != null) {
-      user.address = address;
+      if (name != null) user.name = name;
+      if (phone != null) user.phone = phone;
+      if (street != null) user.street = street;
+      if (province != null) user.province = province;
+      if (city != null) user.city = city;
       emit(AuthState(currentUser: user));
     }
   }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -2,16 +2,28 @@ import 'product.dart';
 
 class User {
   final String email;
+  final String username;
   final String password;
   final bool isAdmin;
-  String address;
+  String name;
+  String phone;
+  String street;
+  String province;
+  String city;
+  String country;
   final List<Product> orderHistory;
 
   User({
     required this.email,
+    required this.username,
     required this.password,
     this.isAdmin = false,
-    this.address = '',
+    this.name = '',
+    this.phone = '',
+    this.street = '',
+    this.province = '',
+    this.city = '',
+    this.country = 'República Dominicana',
     List<Product>? orderHistory,
   }) : orderHistory = orderHistory ?? [];
 }

--- a/lib/pages/cart_page.dart
+++ b/lib/pages/cart_page.dart
@@ -76,7 +76,7 @@ class CartPage extends StatelessWidget {
                 return;
               }
 
-              if (auth.state.currentUser!.address.trim().isEmpty) {
+              if (auth.state.currentUser!.street.trim().isEmpty) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(content: Text('Agrega una dirección en tu perfil')),
                 );

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -14,7 +14,7 @@ class LoginPage extends StatefulWidget {
 }
 
 class _LoginPageState extends State<LoginPage> {
-  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   String? _error;
 
@@ -24,7 +24,7 @@ class _LoginPageState extends State<LoginPage> {
       setState(() => _error = 'Ya has iniciado sesión');
       return;
     }
-    final success = auth.login(_emailController.text, _passwordController.text);
+    final success = auth.login(_usernameController.text, _passwordController.text);
     if (success) {
       context.push('/home');
     } else {
@@ -42,8 +42,8 @@ class _LoginPageState extends State<LoginPage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             TextField(
-              controller: _emailController,
-              decoration: const InputDecoration(labelText: 'Correo electrónico'),
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Nombre de usuario'),
             ),
             const SizedBox(height: 12),
             TextField(

--- a/lib/pages/product_detail_page.dart
+++ b/lib/pages/product_detail_page.dart
@@ -101,10 +101,10 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                             onPressed: () {
                               context.read<CartCubit>().addItemToWishlist(product);
                               ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(content: Text('Añadido a wishlist')),
+                                const SnackBar(content: Text('Añadido a lista de deseo')),
                               );
                             },
-                            child: const Text('Agregar a wishlist'),
+                            child: const Text('Agregar a lista de deseo'),
                           ),
                         ],
                       ),

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -11,23 +11,45 @@ class ProfilePage extends StatefulWidget {
 }
 
 class _ProfilePageState extends State<ProfilePage> {
-  late TextEditingController _addressController;
-
+  late TextEditingController _nameController;
+  late TextEditingController _phoneController;
+  late TextEditingController _streetController;
+  String _selectedProvince = '';
+  String _selectedCity = '';
+  final Map<String, List<String>> _provinces = const {
+    'Distrito Nacional': ['Distrito Nacional'],
+    'Santo Domingo': ['Santo Domingo Este', 'Santo Domingo Norte', 'Santo Domingo Oeste'],
+    'Santiago': ['Santiago de los Caballeros'],
+    'La Vega': ['La Vega', 'Constanza'],
+  };
+  
   @override
   void initState() {
     super.initState();
     final user = context.read<AuthCubit>().state.currentUser;
-    _addressController = TextEditingController(text: user?.address ?? '');
+    _nameController = TextEditingController(text: user?.name ?? '');
+    _phoneController = TextEditingController(text: user?.phone ?? '');
+    _streetController = TextEditingController(text: user?.street ?? '');
+    _selectedProvince = user?.province ?? '';
+    _selectedCity = user?.city ?? '';
   }
 
   @override
   void dispose() {
-    _addressController.dispose();
+    _nameController.dispose();
+    _phoneController.dispose();
+    _streetController.dispose();
     super.dispose();
   }
 
   void _save() {
-    context.read<AuthCubit>().updateAddress(_addressController.text);
+    context.read<AuthCubit>().updateProfile(
+      name: _nameController.text,
+      phone: _phoneController.text,
+      street: _streetController.text,
+      province: _selectedProvince,
+      city: _selectedCity,
+    );
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Dirección guardada')),
     );
@@ -45,8 +67,59 @@ class _ProfilePageState extends State<ProfilePage> {
         child: ListView(
           children: [
             TextField(
-              controller: _addressController,
-              decoration: const InputDecoration(labelText: 'Dirección de envío'),
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Nombre'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _phoneController,
+              decoration: const InputDecoration(labelText: 'Teléfono'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _streetController,
+              decoration: const InputDecoration(labelText: 'Calle'),
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              value: _selectedProvince.isEmpty ? null : _selectedProvince,
+              decoration: const InputDecoration(labelText: 'Provincia'),
+              items: _provinces.keys
+                  .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                  .toList(),
+              onChanged: (value) {
+                setState(() {
+                  _selectedProvince = value ?? '';
+                  _selectedCity = '';
+                });
+              },
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              value: _selectedCity.isEmpty ? null : _selectedCity,
+              decoration: const InputDecoration(labelText: 'Ciudad'),
+              items: (_provinces[_selectedProvince] ?? [])
+                  .map((c) => DropdownMenuItem(value: c, child: Text(c)))
+                  .toList(),
+              onChanged: (value) => setState(() => _selectedCity = value ?? ''),
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              initialValue: 'República Dominicana',
+              enabled: false,
+              decoration: const InputDecoration(labelText: 'País'),
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              initialValue: user?.email ?? '',
+              enabled: false,
+              decoration: const InputDecoration(labelText: 'Correo'),
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              initialValue: user?.username ?? '',
+              enabled: false,
+              decoration: const InputDecoration(labelText: 'Usuario'),
             ),
             const SizedBox(height: 12),
             ElevatedButton(

--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -14,13 +14,33 @@ class RegisterPage extends StatefulWidget {
 
 class _RegisterPageState extends State<RegisterPage> {
   final TextEditingController _email = TextEditingController();
+  final TextEditingController _username = TextEditingController();
   final TextEditingController _password = TextEditingController();
-  final TextEditingController _address = TextEditingController();
+  final TextEditingController _name = TextEditingController();
+  final TextEditingController _phone = TextEditingController();
+  final TextEditingController _street = TextEditingController();
+  String _province = '';
+  String _city = '';
+  final Map<String, List<String>> _provinces = const {
+    'Distrito Nacional': ['Distrito Nacional'],
+    'Santo Domingo': ['Santo Domingo Este', 'Santo Domingo Norte', 'Santo Domingo Oeste'],
+    'Santiago': ['Santiago de los Caballeros'],
+    'La Vega': ['La Vega', 'Constanza'],
+  };
   String? _error;
 
   void _submit() {
     final auth = context.read<AuthCubit>();
-    final success = auth.register(_email.text, _password.text, _address.text);
+    final success = auth.register(
+      email: _email.text,
+      username: _username.text,
+      password: _password.text,
+      name: _name.text,
+      phone: _phone.text,
+      street: _street.text,
+      province: _province,
+      city: _city,
+    );
     if (success) {
       context.push('/home');
     } else {
@@ -31,8 +51,11 @@ class _RegisterPageState extends State<RegisterPage> {
   @override
   void dispose() {
     _email.dispose();
+    _username.dispose();
     _password.dispose();
-    _address.dispose();
+    _name.dispose();
+    _phone.dispose();
+    _street.dispose();
     super.dispose();
   }
 
@@ -51,14 +74,52 @@ class _RegisterPageState extends State<RegisterPage> {
             ),
             const SizedBox(height: 12),
             TextField(
+              controller: _username,
+              decoration: const InputDecoration(labelText: 'Nombre de usuario'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
               controller: _password,
               decoration: const InputDecoration(labelText: 'Contraseña'),
               obscureText: true,
             ),
             const SizedBox(height: 12),
             TextField(
-              controller: _address,
-              decoration: const InputDecoration(labelText: 'Dirección de envío'),
+              controller: _name,
+              decoration: const InputDecoration(labelText: 'Nombre'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _phone,
+              decoration: const InputDecoration(labelText: 'Teléfono'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _street,
+              decoration: const InputDecoration(labelText: 'Calle'),
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              value: _province.isEmpty ? null : _province,
+              decoration: const InputDecoration(labelText: 'Provincia'),
+              items: _provinces.keys
+                  .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                  .toList(),
+              onChanged: (value) {
+                setState(() {
+                  _province = value ?? '';
+                  _city = '';
+                });
+              },
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              value: _city.isEmpty ? null : _city,
+              decoration: const InputDecoration(labelText: 'Ciudad'),
+              items: (_provinces[_province] ?? [])
+                  .map((c) => DropdownMenuItem(value: c, child: Text(c)))
+                  .toList(),
+              onChanged: (value) => setState(() => _city = value ?? ''),
             ),
             if (_error != null) ...[
               const SizedBox(height: 8),

--- a/lib/pages/wishlist_page.dart
+++ b/lib/pages/wishlist_page.dart
@@ -13,7 +13,7 @@ class WishlistPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: const AppHeader(title: 'Lista de deseos', showBack: true),
+      appBar: const AppHeader(title: 'Lista de deseo', showBack: true),
       body: BlocBuilder<CartCubit, CartState>(
         builder: (context, state) {
           final items = state.wishlist;


### PR DESCRIPTION
## Summary
- expand `User` model with profile fields and username
- support username login in `AuthCubit`
- collect profile info during registration
- update profile screen to edit name, phone, and address parts
- update login page to request username
- change wishlist labels to "Lista de deseo"

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688846b9103c8321aa97f10e009b8d53